### PR TITLE
feat: 장바구니 단일 가게 제한 로직 구현

### DIFF
--- a/baemin/src/main/java/com/sist/baemin/order/domain/CartEntity.java
+++ b/baemin/src/main/java/com/sist/baemin/order/domain/CartEntity.java
@@ -1,6 +1,5 @@
 package com.sist.baemin.order.domain;
 
-import com.sist.baemin.menu.domain.MenuEntity;
 import com.sist.baemin.store.domain.StoreEntity;
 import com.sist.baemin.user.domain.UserEntity;
 import jakarta.persistence.*;
@@ -9,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -33,5 +33,8 @@ public class CartEntity {
     
     @Column(name = "createdAt")
     private LocalDateTime createdAt;
+    
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<CartItemEntity> cartItems = new ArrayList<>();
 
 }

--- a/baemin/src/main/resources/static/css/menu-detail.css
+++ b/baemin/src/main/resources/static/css/menu-detail.css
@@ -509,3 +509,26 @@ body {
 .option-value-price.free {
     color: var(--baemin-gray);
 }
+
+/* 확인 모달 스타일 */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 10000;
+}
+
+.modal-content {
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    max-width: 400px;
+    width: 90%;
+    text-align: center;
+}

--- a/baemin/src/main/resources/static/js/menu-detail.js
+++ b/baemin/src/main/resources/static/js/menu-detail.js
@@ -158,20 +158,25 @@ function addToCart() {
         // 전송된 JSON 데이터를 문자열로 변환
         const jsonString = JSON.stringify(cartData, null, 2);
         
-        if (data.success) {
-            alert(data.message + '\n\n전송된 데이터:\n' + jsonString);
-            // 장바구니 페이지로 이동
+        // needConfirmation이 true인 경우 모달 표시
+        if (data.data && data.data.needConfirmation) {
+            // 사용자 확인이 필요한 경우 모달 표시
+            showConfirmationModal(cartData);
+        } else if (data.success) {
+            // 정상적으로 추가된 경우 장바구니 페이지로 이동
             location.href = '/api/cart/page';
         } else {
             // 서버에서 보낸 메시지를 그대로 표시
             alert(data.message);
             // 버튼 상태 복원
-            cartButton.disabled = false;
-            const totalPriceElement = document.getElementById('totalPrice');
-            if (totalPriceElement) {
-                cartButton.innerHTML = '<span id="totalPrice">' + totalPriceElement.textContent + '</span>';
-            } else {
-                cartButton.textContent = '담기';
+            if (cartButton) {
+                cartButton.disabled = false;
+                const totalPriceElement = document.getElementById('totalPrice');
+                if (totalPriceElement) {
+                    cartButton.innerHTML = '<span id="totalPrice">' + totalPriceElement.textContent + '</span>';
+                } else {
+                    cartButton.textContent = '담기';
+                }
             }
         }
     })
@@ -180,12 +185,173 @@ function addToCart() {
         // 에러 메시지를 그대로 표시 (서버에서 보낸 메시지 포함)
         alert(error.message);
         // 버튼 상태 복원
-        cartButton.disabled = false;
-        const totalPriceElement = document.getElementById('totalPrice');
-        if (totalPriceElement) {
-            cartButton.innerHTML = '<span id="totalPrice">' + totalPriceElement.textContent + '</span>';
+        if (cartButton) {
+            cartButton.disabled = false;
+            const totalPriceElement = document.getElementById('totalPrice');
+            if (totalPriceElement) {
+                cartButton.innerHTML = '<span id="totalPrice">' + totalPriceElement.textContent + '</span>';
+            } else {
+                cartButton.textContent = '담기';
+            }
+        }
+    });
+}
+
+// 확인 모달 표시
+function showConfirmationModal(cartData) {
+    // 기존 모달이 있으면 제거
+    const existingModal = document.getElementById('confirmationModal');
+    if (existingModal) {
+        existingModal.remove();
+    }
+    
+    // 모달 HTML 생성
+    const modal = document.createElement('div');
+    modal.id = 'confirmationModal';
+    modal.className = 'modal';
+    modal.style.cssText = `
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0,0,0,0.5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 10000;
+    `;
+    
+    modal.innerHTML = `
+        <div style="
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            max-width: 400px;
+            width: 90%;
+            text-align: center;
+        ">
+            <h3 style="margin-top: 0;">장바구니 확인</h3>
+            <p>다른 가게의 장바구니가 존재합니다. 기존 장바구니를 비우고 새로운 가게의 메뉴를 추가하시겠습니까?</p>
+            <div style="margin-top: 20px;">
+                <button id="cancelBtn" style="
+                    padding: 10px 20px;
+                    margin-right: 10px;
+                    background: #ccc;
+                    border: none;
+                    border-radius: 4px;
+                    cursor: pointer;
+                ">취소</button>
+                <button id="confirmBtn" style="
+                    padding: 10px 20px;
+                    background: #2ac1bc;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    cursor: pointer;
+                ">확인</button>
+            </div>
+        </div>
+    `;
+    
+    // 모달을 페이지에 추가
+    document.body.appendChild(modal);
+    
+    // 이벤트 리스너 등록
+    document.getElementById('cancelBtn').addEventListener('click', function() {
+        document.getElementById('confirmationModal').remove();
+        // 버튼 상태 복원
+        const cartButton = document.querySelector('.btn-cart');
+        if (cartButton) {
+            cartButton.disabled = false;
+            const totalPriceElement = document.getElementById('totalPrice');
+            if (totalPriceElement) {
+                cartButton.innerHTML = '<span id="totalPrice">' + totalPriceElement.textContent + '</span>';
+            } else {
+                cartButton.textContent = '담기';
+            }
+        }
+    });
+    
+    document.getElementById('confirmBtn').addEventListener('click', function() {
+        document.getElementById('confirmationModal').remove();
+        // 확인 후 장바구니에 추가
+        addToCartWithConfirmation(cartData);
+    });
+}
+
+// 사용자 확인 후 장바구니에 추가
+function addToCartWithConfirmation(cartData) {
+    // 버튼 비활성화
+    const cartButton = document.querySelector('.btn-cart');
+    if (cartButton) {
+        cartButton.disabled = true;
+        cartButton.textContent = '담는 중...';
+    }
+    
+    // JWT 토큰 가져오기 (쿠키에서)
+    const token = getCookie('Authorization');
+    const headers = {
+        'Content-Type': 'application/json',
+    };
+    
+    // 토큰이 있으면 Authorization 헤더 추가
+    if (token) {
+        headers['Authorization'] = 'Bearer ' + token;
+    }
+    
+    fetch('/api/cart/items/confirm', {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(cartData)
+    })
+    .then(response => {
+        if (!response.ok) {
+            // 401/403 등 HTTP 에러의 경우에도 JSON 응답을 파싱
+            return response.json().then(errorData => {
+                throw new Error(errorData.message || `HTTP ${response.status}: ${response.statusText}`);
+            }).catch(() => {
+                // JSON 파싱 실패시 기본 에러 메시지
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            });
+        }
+        return response.json();
+    })
+    .then(data => {
+        // 전송된 JSON 데이터를 문자열로 변환
+        const jsonString = JSON.stringify(cartData, null, 2);
+        
+        if (data.success) {
+            // 성공적으로 추가된 경우 장바구니 페이지로 이동
+            location.href = '/api/cart/page';
         } else {
-            cartButton.textContent = '담기';
+            // 서버에서 보낸 메시지를 그대로 표시
+            alert(data.message || '장바구니 추가 중 오류가 발생했습니다.');
+            // 버튼 상태 복원
+            if (cartButton) {
+                cartButton.disabled = false;
+                const totalPriceElement = document.getElementById('totalPrice');
+                if (totalPriceElement) {
+                    cartButton.innerHTML = '<span id="totalPrice">' + totalPriceElement.textContent + '</span>';
+                } else {
+                    cartButton.textContent = '담기';
+                }
+            }
+        }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        // 에러 메시지를 그대로 표시 (서버에서 보낸 메시지 포함)
+        alert(error.message || '장바구니 추가 중 오류가 발생했습니다.');
+        // 버튼 상태 복원
+        if (cartButton) {
+            cartButton.disabled = false;
+            const totalPriceElement = document.getElementById('totalPrice');
+            if (totalPriceElement) {
+                cartButton.innerHTML = '<span id="totalPrice">' + totalPriceElement.textContent + '</span>';
+            } else {
+                cartButton.textContent = '담기';
+            }
         }
     });
 }


### PR DESCRIPTION
- 한 사용자가 한 번에 하나의 가게에서만 장바구니를 가질 수 있도록 제한
- 다른 가게의 메뉴 추가 시 기존 장바구니를 자동 삭제하고 새로운 장바구니 생성
- 사용자 확인 모달 추가로 기존 장바구니 삭제 전 사용자에게 재확인